### PR TITLE
Batch Publish

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -79,5 +80,6 @@ namespace RabbitMQ.Client.Impl
         void HandleFrame(InboundFrame frame);
         void Notify();
         void Transmit(Command cmd);
+        void Transmit(IEnumerable<Command> cmd);
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
@@ -41,6 +41,7 @@
 using System;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing.Impl;
+using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -198,6 +199,10 @@ namespace RabbitMQ.Client.Impl
             // We used to transmit *inside* the lock to avoid interleaving
             // of frames within a channel.  But that is fixed in socket frame handler instead, so no need to lock.
             cmd.Transmit(ChannelNumber, Connection);
+        }
+        public virtual void Transmit(IEnumerable<Command> commands)
+        {
+            Connection.WriteFrameSet(Command.CalculateFrames(ChannelNumber, Connection, commands));
         }
     }
 }


### PR DESCRIPTION


## Proposed Changes

Batch publish allows sending multiple messages in one stream on the socket.
Sending in batches improves performance by reducing the number of TCP/IP messages sent and TCP/IP acknowledgments received.
This change compiles the commands for all publish messages into a memory buffer that is posted to the socket as a single stream.
Closing the socket/model/connection before the buffer has completed sending does not guarantee message delivery.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [ ] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

n/a